### PR TITLE
Improvements + Bug Fixes for Wallet Duster Skill

### DIFF
--- a/packages/plugin-wallet-duster/src/actions/dustPreview.ts
+++ b/packages/plugin-wallet-duster/src/actions/dustPreview.ts
@@ -198,6 +198,47 @@ export const previewDustAction: Action = {
                 },
             },
         ],
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Preview dusting my wallet",
+                },
+            },
+            {
+                user: "{{user2}}",
+                content: {
+                    text: "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
+                    action: "PREVIEW_DUST_TOKENS",
+                },
+            },
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Great! can you dust them all?",
+                },
+            },
+            {
+                user: "{{user2}}",
+                content: {
+                    text: "You are trying to dust tokens under $5 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
+                    action: "DUST_WALLET_TO_ETH",
+                },
+            },
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Yes, proceed",
+                },
+            },
+            {
+                user: "{{user2}}",
+                content: {
+                    text: "Dusted 1 token under $5 into ETH.",
+                    action: "DUST_WALLET_TO_ETH",
+                },
+            },
+        ],
     ],
     handler: async (
         runtime: IAgentRuntime,

--- a/packages/plugin-wallet-duster/src/actions/dustPreview.ts
+++ b/packages/plugin-wallet-duster/src/actions/dustPreview.ts
@@ -17,16 +17,15 @@ import { ETH_ADDRESS } from "../constants/constants";
 export const previewDustAction: Action = {
     name: "PREVIEW_DUST_TOKENS",
     similes: [
-        "PREVIEW_DUST",
         "SHOW_DUST_TOKENS",
         "WHAT_TOKENS_WILL_BE_DUSTED",
         "LIST_LOW_VALUE_TOKENS",
         "SHOW_TOKENS_BELOW_USD",
         "SHOW_TOKENS_BELOW_VALUE",
         "SHOW_TOKENS_BELOW_THRESHOLD",
-        "DUST_PREVIEW",
         "HOW_MUCH_DUST_IN_WALLET",
         "HOW_MANY_DUST_TOKENS_IN_WALLET",
+        "WHAT_VALUE_OF_DUST_IN_WALLET",
     ],
     description:
         "Select this action when user request to preview/show how much or how many dust or low-value tokens would be dusted based on USD threshold given by user. By default, the threshold is $5. Use this action if user only ask to preview or display the dust tokens, NOT when user ask to dust the tokens.",
@@ -236,6 +235,21 @@ export const previewDustAction: Action = {
                 content: {
                     text: "Dusted 1 token under $5 into ETH.",
                     action: "DUST_WALLET_TO_ETH",
+                },
+            },
+        ],
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "What's the value of dust in my agent wallet?",
+                },
+            },
+            {
+                user: "{{user2}}",
+                content: {
+                    text: "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
+                    action: "PREVIEW_DUST_TOKENS",
                 },
             },
         ],

--- a/packages/plugin-wallet-duster/src/actions/dustWalletAction.ts
+++ b/packages/plugin-wallet-duster/src/actions/dustWalletAction.ts
@@ -33,12 +33,12 @@ export const dustWalletAction: Action = {
         "SELL_ALL_TOKENS_UNDER",
         "DUST_TOKENS",
         "DUST_WALLET",
-        "DUST_TOKENS_UNDER",
-        "DUST_TOKENS_BELOW",
+        "DUST_TOKENS_UNDER_USD",
+        "DUST_TOKENS_BELOW_USD",
     ],
     validate: async () => true,
     description:
-        "Dust any low-value ERC20 tokens in the user's agent wallet under a given USD value threshold and dusts them to ETH on Base. Select this action when user request to dust their wallet and NOT just simply display/preview the dust tokens, e.g. 'Dust tokens under $5'.",
+        "Dust any low-value ERC20 tokens in the user's agent wallet under a given USD $ value threshold and dusts them to ETH on Base. Select this action when user request to dust their wallet and NOT just simply display/preview the dust tokens, e.g. 'Dust tokens under $5'.",
     suppressInitialMessage: true,
     examples: [
         [
@@ -101,13 +101,13 @@ export const dustWalletAction: Action = {
             {
                 user: "{{user1}}",
                 content: {
-                    text: "Dust tokens under $10",
+                    text: "Dust tokens under $<USD_THRESHOLD>",
                 },
             },
             {
                 user: "{{user2}}",
                 content: {
-                    text: "Dusted 4 tokens under $10 into ETH.",
+                    text: "Dusted 4 tokens under $<USD_THRESHOLD> into ETH.",
                     action: "DUST_WALLET_TO_ETH",
                 },
             },

--- a/packages/plugin-wallet-duster/src/actions/dustWalletAction.ts
+++ b/packages/plugin-wallet-duster/src/actions/dustWalletAction.ts
@@ -38,24 +38,13 @@ export const dustWalletAction: Action = {
     ],
     validate: async () => true,
     description:
-        "Dust any dust or low-value tokens in your agent wallet under a given USD value threshold and dusts them to ETH on Base. Select this action when user request to dust their wallet and not just simply display the dust tokens, which will require confirmation and gas fee payments.",
+        "Dust any low-value ERC20 tokens in the user's agent wallet under a given USD value threshold and dusts them to ETH on Base. Select this action when user request to dust their wallet and NOT just simply display/preview the dust tokens, e.g. 'Dust tokens under $5'.",
     suppressInitialMessage: true,
     examples: [
         [
             {
                 user: "{{user1}}",
                 content: { text: "Dust my wallet for anything under $5." },
-            },
-            {
-                user: "{{user2}}",
-                content: {
-                    text: "You are trying to dust tokens under $5 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-                    action: "DUST_WALLET_TO_ETH",
-                },
-            },
-            {
-                user: "{{user1}}",
-                content: { text: "Yes, proceed" },
             },
             {
                 user: "{{user2}}",
@@ -69,16 +58,6 @@ export const dustWalletAction: Action = {
             {
                 user: "{{user1}}",
                 content: { text: "Dust my wallet" },
-            },
-            {
-                user: "{{user2}}",
-                content: {
-                    text: "You are trying to dust tokens under $5 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-                },
-            },
-            {
-                user: "{{user1}}",
-                content: { text: "Yes, proceed" },
             },
             {
                 user: "{{user2}}",
@@ -98,16 +77,6 @@ export const dustWalletAction: Action = {
             {
                 user: "{{user2}}",
                 content: {
-                    text: "You are trying to dust tokens under $10 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-                },
-            },
-            {
-                user: "{{user1}}",
-                content: { text: "Yes, proceed" },
-            },
-            {
-                user: "{{user2}}",
-                content: {
                     text: "Dusted 4 tokens under $10 into ETH.",
                     action: "DUST_WALLET_TO_ETH",
                 },
@@ -119,16 +88,6 @@ export const dustWalletAction: Action = {
                 content: {
                     text: "Clear all the low-value tokens from my wallet.",
                 },
-            },
-            {
-                user: "{{user2}}",
-                content: {
-                    text: "You are trying to dust tokens under $5 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-                },
-            },
-            {
-                user: "{{user1}}",
-                content: { text: "Yes, proceed" },
             },
             {
                 user: "{{user2}}",
@@ -148,37 +107,9 @@ export const dustWalletAction: Action = {
             {
                 user: "{{user2}}",
                 content: {
-                    text: "You are trying to dust tokens under $10 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-                },
-            },
-            {
-                user: "{{user1}}",
-                content: { text: "Yes, proceed" },
-            },
-            {
-                user: "{{user2}}",
-                content: {
                     text: "Dusted 4 tokens under $10 into ETH.",
                     action: "DUST_WALLET_TO_ETH",
                 },
-            },
-        ],
-        [
-            {
-                user: "{{user1}}",
-                content: {
-                    text: "Dust tokens under $5",
-                },
-            },
-            {
-                user: "{{user2}}",
-                content: {
-                    text: "You are trying to dust tokens under $5 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-                },
-            },
-            {
-                user: "{{user1}}",
-                content: { text: "No.", action: "DUST_WALLET_TO_ETH" },
             },
         ],
     ],

--- a/packages/plugin-wallet-duster/src/templates.ts
+++ b/packages/plugin-wallet-duster/src/templates.ts
@@ -18,11 +18,11 @@ Provide the values in the following JSON format:
   - Extract the dollar value if user says things like "dust tokens under $X".
   - If not specified, set to null.
 - **isConfirmed**:
-  - If the most recent action is "PREVIEW_DUST_WALLET_TO_ETH":
+  - If the most recent action is "PREVIEW_DUST_TOKENS":
     - If user confirms afterward ("Yes", "Proceed", "Go ahead") → true
     - If user rejects ("No", "Cancel") → false
     - If no follow-up confirmation/rejection yet → null
-  - If the most recent action is "DUST_WALLET_TO_ETH" without preview → true
+  - If the most recent action is "DUST_WALLET_TO_ETH" without any previous preview request → true
   - If a new dusting request is issued (e.g., new threshold, or repeat command), reset both values to null.
 Note: Always ensure that confirmation follows a preview. If a user previews but hasn’t yet responded, **isConfirmed** must stay null – even if the request looks positive.
 Here are some examples of user's conversation with the agent and the expected response:
@@ -78,7 +78,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
-            "action": "PREVIEW_DUST_WALLET_TO_ETH"
+            "action": "PREVIEW_DUST_TOKENS"
         }
     },
     {
@@ -123,7 +123,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
-            "action": "PREVIEW_DUST_WALLET_TO_ETH"
+            "action": "PREVIEW_DUST_TOKENS"
         }
     },
     {
@@ -155,7 +155,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "Here are the tokens under $15 in your wallet: 0x123... (1000 tokens worth $4.99)",
-            "action": "PREVIEW_DUST_WALLET_TO_ETH"
+            "action": "PREVIEW_DUST_TOKENS"
         }
     },
     {
@@ -200,7 +200,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "Here are the tokens under $15 in your wallet: 0x123... (1000 tokens worth $4.99)",
-            "action": "PREVIEW_DUST_WALLET_TO_ETH"
+            "action": "PREVIEW_DUST_TOKENS"
         }
     },
     {
@@ -232,7 +232,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "Here are the tokens under $1 in your wallet: 0x123... (1000 tokens worth $4.99)",
-            "action": "PREVIEW_DUST_WALLET_TO_ETH"
+            "action": "PREVIEW_DUST_TOKENS"
         }
     },
     {

--- a/packages/plugin-wallet-duster/src/templates.ts
+++ b/packages/plugin-wallet-duster/src/templates.ts
@@ -25,8 +25,8 @@ Provide the result in the following JSON format:
 1. Direct Dusting Requests (no preview involved)
 - If the user says “Dust tokens under $X” or “Dust my tokens” without a prior PREVIEW_DUST_TOKENS action, set \`isConfirmed: true\`
 2. Preview Flow
-- If the last action is \`PREVIEW_DUST_TOKENS\`, only set \`isConfirmed: true\` if the user explicitly confirms afterward, such as:
-    - "Yes", "Proceed", "Confirm", "Go ahead", "Dust them all"
+- If the last action is \`PREVIEW_DUST_TOKENS\`, only set \`isConfirmed: true\` if the user explicitly confirms after requesting the dusting after the preview, such as:
+    - "Yes", "Proceed", "Confirm", "Go ahead"
 - If the user says "No", "Cancel", or similar, set \`isConfirmed: false\`
 - If no clear confirmation or rejection yet, set \`isConfirmed: null\`
 3. Dusting Without Preview

--- a/packages/plugin-wallet-duster/src/templates.ts
+++ b/packages/plugin-wallet-duster/src/templates.ts
@@ -18,11 +18,11 @@ Provide the values in the following JSON format:
   - Extract the dollar value if user says things like "dust tokens under $X".
   - If not specified, set to null.
 - **isConfirmed**:
-  - If the most recent action is "PREVIEW_DUSTING_MY_WALLET":
+  - If the most recent action is "PREVIEW_DUST_WALLET_TO_ETH":
     - If user confirms afterward ("Yes", "Proceed", "Go ahead") → true
     - If user rejects ("No", "Cancel") → false
     - If no follow-up confirmation/rejection yet → null
-  - If the most recent action is "DUST_TOKENS" without preview → true
+  - If the most recent action is "DUST_WALLET_TO_ETH" without preview → true
   - If a new dusting request is issued (e.g., new threshold, or repeat command), reset both values to null.
 Note: Always ensure that confirmation follows a preview. If a user previews but hasn’t yet responded, **isConfirmed** must stay null – even if the request looks positive.
 Here are some examples of user's conversation with the agent and the expected response:
@@ -78,7 +78,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
-            "action": "PREVIEW_DUSTING_MY_WALLET"
+            "action": "PREVIEW_DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -110,7 +110,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "Dusted 3 dust tokens into ETH.",
-            "action": "DUST_TOKENS"
+            "action": "DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -123,7 +123,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
-            "action": "PREVIEW_DUSTING_MY_WALLET"
+            "action": "PREVIEW_DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -155,7 +155,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "Here are the tokens under $15 in your wallet: 0x123... (1000 tokens worth $4.99)",
-            "action": "PREVIEW_DUSTING_MY_WALLET"
+            "action": "PREVIEW_DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -168,7 +168,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "You are trying to dust tokens under $15 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-            "action": "DUST_TOKENS"
+            "action": "DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -200,7 +200,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "Here are the tokens under $15 in your wallet: 0x123... (1000 tokens worth $4.99)",
-            "action": "PREVIEW_DUSTING_MY_WALLET"
+            "action": "PREVIEW_DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -213,7 +213,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "You are trying to dust tokens under $15 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-            "action": "DUST_TOKENS"
+            "action": "DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -232,7 +232,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "Here are the tokens under $1 in your wallet: 0x123... (1000 tokens worth $4.99)",
-            "action": "PREVIEW_DUSTING_MY_WALLET"
+            "action": "PREVIEW_DUST_WALLET_TO_ETH"
         }
     },
     {
@@ -245,7 +245,7 @@ Here are some examples of user's conversation with the agent and the expected re
         "user": "{{user2}}",
         "content": {
             "text": "You are trying to dust tokens under $1 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
-            "action": "DUST_TOKENS"
+            "action": "DUST_WALLET_TO_ETH"
         }
     },
 ]

--- a/packages/plugin-wallet-duster/src/templates.ts
+++ b/packages/plugin-wallet-duster/src/templates.ts
@@ -1,9 +1,9 @@
 import { ethers } from "ethers";
 
 export const dustRequestTemplate = `
-Provide the following details to dust tokens in your wallet:
+Based on user's recent messages with the agent, provide the following details to dust tokens in your wallet:
 - **threshold** (Number): The USD threshold for a token to be considered dust tokens.
-- **isConfirmed** (Boolean): Whether the user has confirmed the dusting.
+- **isConfirmed** (Boolean): Whether the user has given any consent/confirmation to the dusting based on the user's recent messages.
 Provide the values in the following JSON format:
 \`\`\`json
 {
@@ -12,6 +12,20 @@ Provide the values in the following JSON format:
 }
 \`\`\`
 "?" indicates that the value is optional.
+## General Rules
+## Value Extraction Rules
+- **threshold**:
+  - Extract the dollar value if user says things like "dust tokens under $X".
+  - If not specified, set to null.
+- **isConfirmed**:
+  - If the most recent action is "PREVIEW_DUSTING_MY_WALLET":
+    - If user confirms afterward ("Yes", "Proceed", "Go ahead") → true
+    - If user rejects ("No", "Cancel") → false
+    - If no follow-up confirmation/rejection yet → null
+  - If the most recent action is "DUST_TOKENS" without preview → true
+  - If a new dusting request is issued (e.g., new threshold, or repeat command), reset both values to null.
+Note: Always ensure that confirmation follows a preview. If a user previews but hasn’t yet responded, **isConfirmed** must stay null – even if the request looks positive.
+Here are some examples of user's conversation with the agent and the expected response:
 # Example 1
 **Message 1**
 \`\`\`
@@ -19,19 +33,7 @@ Provide the values in the following JSON format:
     {
         "user": "{{user1}}",
         "content": {
-            "text": "Dust tokens under $5"
-        }
-    },
-    {
-        "user": "{{user2}}",
-        "content": {
-            "text": "You are trying to dust tokens under $5 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?"
-        }
-    },
-    {
-        "user": "{{user1}}",
-        "content": {
-            "text": "Yes, proceed"
+            "text": "Dust tokens under $1"
         }
     }
 ]
@@ -39,7 +41,7 @@ Provide the values in the following JSON format:
 **Response 1**
 \`\`\`json
 {
-    "threshold": 5,
+    "threshold": 1,
     "isConfirmed": true
 }
 \`\`\`
@@ -50,19 +52,7 @@ Provide the values in the following JSON format:
     {
         "user": "{{user1}}",
         "content": {
-            "text": "Dust tokens under $10"
-        }
-    },
-    {
-        "user": "{{user2}}",
-        "content": {
-            "text": "You are trying to dust tokens under $10 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?"
-        }
-    },
-    {
-        "user": "{{user1}}",
-        "content": {
-            "text": "No."
+            "text": "Dust my tokens"
         }
     }
 ]
@@ -70,31 +60,200 @@ Provide the values in the following JSON format:
 **Response 2**
 \`\`\`json
 {
-    "threshold": 10,
-    "isConfirmed": false
+    "threshold": null,
+    "isConfirmed": true
 }
 \`\`\`
-# Example 3
+# Example 3 (Combination with preview action)
 **Message 3**
 \`\`\`
-Dust tokens under $1
+[
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Preview dusting my wallet"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
+            "action": "PREVIEW_DUSTING_MY_WALLET"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Great! can you dust them all?"
+        }
+    },
+]
 \`\`\`
 **Response 3**
 \`\`\`json
 {
-    "threshold": 1,
+    "threshold": null,
     "isConfirmed": null
 }
 \`\`\`
-# Example 4
+# Example 4 (Combination with preview action)
 **Message 4**
 \`\`\`
-Dust my tokens
+[
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "dust tokens under $1"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "Dusted 3 dust tokens into ETH.",
+            "action": "DUST_TOKENS"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Preview dusting my wallet"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "You have 1 dust token(s) totaling ~ $0.08: 0x123... (1000 tokens worth $0.08)",
+            "action": "PREVIEW_DUSTING_MY_WALLET"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Great! can you dust them all?"
+        }
+    },
+]
 \`\`\`
 **Response 4**
 \`\`\`json
 {
     "threshold": null,
+    "isConfirmed": null
+}
+\`\`\`
+# Example 4 (Combination with preview action and extracting from historical messages)
+**Message 4**
+\`\`\`
+[
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Preview dusting all tokens under $15"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "Here are the tokens under $15 in your wallet: 0x123... (1000 tokens worth $4.99)",
+            "action": "PREVIEW_DUSTING_MY_WALLET"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Great! can you dust them all?"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "You are trying to dust tokens under $15 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
+            "action": "DUST_TOKENS"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Yes, proceed"
+        }
+    }
+]
+\`\`\`
+**Response 4**
+\`\`\`json
+{
+    "threshold": 15,
+    "isConfirmed": true
+}
+\`\`\`
+# Example 5 (Combination with preview action and extracting from historical messages + new request that invalidates the previous request)
+**Message 5**
+\`\`\`
+[
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Preview dusting all tokens under $15"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "Here are the tokens under $15 in your wallet: 0x123... (1000 tokens worth $4.99)",
+            "action": "PREVIEW_DUSTING_MY_WALLET"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Great! can you dust them all?"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "You are trying to dust tokens under $15 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
+            "action": "DUST_TOKENS"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Yes, proceed"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "Thanks, now can you show all dust tokens under $1"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "Here are the tokens under $1 in your wallet: 0x123... (1000 tokens worth $4.99)",
+            "action": "PREVIEW_DUSTING_MY_WALLET"
+        }
+    },
+    {
+        "user": "{{user1}}",
+        "content": {
+            "text": "dust them all pls"
+        }
+    },
+    {
+        "user": "{{user2}}",
+        "content": {
+            "text": "You are trying to dust tokens under $1 from your agent wallet. Depending on the number of tokens, this may take a several minutes to complete. \n\nDo you want to proceed?",
+            "action": "DUST_TOKENS"
+        }
+    },
+]
+\`\`\`
+**Response 5**
+\`\`\`json
+{
+    "threshold": 1,
     "isConfirmed": null
 }
 \`\`\`

--- a/registry/src/skills.json
+++ b/registry/src/skills.json
@@ -710,7 +710,7 @@
             {
                 "label": "Show 7 day PNL for #copytrade group",
                 "value": "Show 7 day PNL for #[copytrade|7b37936c-d06c-4b54-8179-3190ecc1f0b3] group"
-            }      
+            }
         ],
         "mediaUrls": [
             "https://raw.githubusercontent.com/Senpi-ai/senpi-agent-skills/refs/heads/main/packages/plugin-moxie-pnl-tracker/images/logo.svg"
@@ -867,21 +867,20 @@
             "WHAT_DOES_THE_WALLET_DUSTING_SKILL_DO",
             "EXPLAIN_WALLET_DUSTING",
             "WHAT_IS_WALLET_DUSTING",
-            "PREVIEW_DUST",
             "SHOW_DUST_TOKENS",
             "WHAT_TOKENS_WILL_BE_DUSTED",
             "LIST_LOW_VALUE_TOKENS",
             "SHOW_TOKENS_BELOW_USD",
             "SHOW_TOKENS_BELOW_VALUE",
             "SHOW_TOKENS_BELOW_THRESHOLD",
-            "DUST_PREVIEW",
             "PREVIEW_DUST_TOKENS",
             "DUST_TOKENS",
             "DUST_WALLET",
-            "DUST_TOKENS_UNDER",
-            "DUST_TOKENS_BELOW",
+            "DUST_TOKENS_UNDER_USD",
+            "DUST_TOKENS_BELOW_USD",
             "HOW_MUCH_DUST_IN_WALLET",
-            "HOW_MANY_DUST_TOKENS_IN_WALLET"
+            "HOW_MANY_DUST_TOKENS_IN_WALLET",
+            "WHAT_VALUE_OF_DUST_IN_WALLET"
         ],
         "isPremium": false,
         "freeQueries": 0,


### PR DESCRIPTION
# Background

Some improvements on the wallet duster skill:

1. Improve accuracy to select the dusting action instead of the preview action

In the previous release, "dust tokens under $..." tends to select the preview action instead of the actual dusting skill itself.

With the changes, the accuracy should be improved and the dusting action will be selected for all dusting-related prompts instead of the preview ones:

![image](https://github.com/user-attachments/assets/b50870c7-bb10-450b-9851-57943d485c61)

2. Dusting based on historical messages

Originally the skill only dust based on the latest message and when not specified, e.g. "dust them all", it will default the threshold to $5.

With the changes, now it can get it from historical message user have w/ the agent:

![image](https://github.com/user-attachments/assets/37be31f2-91fb-49f6-aeed-332f18985667)

3. Remove permission when user request directly dusting

Originally consent is required for all dusting requests. However, with this change, the agent will only ask consent if user first preview the dusting. If none, then directly execute the dusting process.



# PR Category

<!--
Please choose one of the following category that suits your PR the most.

For bug fixes, please specify the severity level of the bug fixed.
-->

- [ ] Register New Skills (first time adding new skills to moxie.xyz)
- [ ] Bug Fixes (non-breaking change which fixes an issue)
    - [ ] Low
    - [ ] Medium
    - [ ] High
- [x] Improvements (misc. changes to existing features)
- [ ] New Features (non-breaking change which adds functionality)
- [ ] Updates (new versions of included code)

# Description

<!--
Briefly provide bullet points on what kind of change is done in the PR.
-->

<!--
IF YOU ARE REGISTERING FOR NEW SKILLS, UNCOMMENT THIS AND MAKE SURE TO FULFILL ALL THE CHECKLIST BELOW:
- [] Have tested the skills with the agent locally and working well
- [] Have a well-writen README for the skills full description of the functionality along with detailed list of all actions, providers, evaluators, services, and clients.
- [] Have added the new skill metadata to the `registry/src/skill.json` registry
- [] Have not made changes to other aspects of the repository other than the folder containing the new skills
- [] (Optional) Have environment variables and have requested the Moxie team through [this form](https://forms.gle/8hzDyCVKKLs4MkTEA) for environment variables submission.
- [] Does not contain any code that simply transfers Moxie user's holdings to a fixed address
- [] Does not contain any code that extracts Moxie user's private informations (e.g. wallets, private keys, etc.)
- [] Does not contain any code that interacts with smart contracts that has not verified and published its source code.
- [] Have audited smart contracts if the skills contain code that interacts with smart contracts has volume/balance above 100k USD.
-->

# Detailed Testing Steps <!-- COMMENT OUT OR DELETE IF REGISTERING NEW SKILLS -->

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

