### PR TITLE
Fix autonomous trading issue

### DIFF
--- a/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
+++ b/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
@@ -11,9 +11,27 @@ import {
     composeContext,
     generateObjectDeprecated,
 } from "@moxie-protocol/core";
-import { MoxieClientWallet, MoxieUser, MoxieWalletClient, formatUserMention } from "@moxie-protocol/moxie-agent-lib";
-import { BaseParams, createTradingRule, getAutonomousTradingRuleDetails, getErrorMessageFromCode, GroupTradeParams, LimitOrderParams, RuleType, 
-    UserTradeParams, agentWalletNotFound, delegateAccessNotFound, moxieWalletClientNotFound, checkUserCommunicationPreferences, Condition } from "../utils/utility";
+import {
+    MoxieClientWallet,
+    MoxieUser,
+    MoxieWalletClient,
+    formatUserMention,
+} from "@moxie-protocol/moxie-agent-lib";
+import {
+    BaseParams,
+    createTradingRule,
+    getAutonomousTradingRuleDetails,
+    getErrorMessageFromCode,
+    GroupTradeParams,
+    LimitOrderParams,
+    RuleType,
+    UserTradeParams,
+    agentWalletNotFound,
+    delegateAccessNotFound,
+    moxieWalletClientNotFound,
+    checkUserCommunicationPreferences,
+    Condition,
+} from "../utils/utility";
 import { autonomousTradingTemplate } from "../templates";
 
 export interface TokenAge {
@@ -36,11 +54,11 @@ export interface AutonomousTradingRuleParams {
     timeDurationInSec: number;
     amountInUSD: number;
     profitPercentage?: number;
-    condition?: 'ANY' | 'ALL';
+    condition?: "ANY" | "ALL";
     conditionValue?: number;
     minPurchaseAmount?: number;
-    sellTriggerType?: 'LIMIT_ORDER' | 'COPY_SELL' | 'BOTH';
-    sellTriggerCondition?: 'ANY' | 'ALL';
+    sellTriggerType?: "LIMIT_ORDER" | "COPY_SELL" | "BOTH";
+    sellTriggerCondition?: "ANY" | "ALL";
     sellTriggerCount?: number;
     sellPercentage?: number;
     tokenAge?: TokenAge;
@@ -60,7 +78,6 @@ export interface AutonomousTradingResponse {
     error: AutonomousTradingError | null;
 }
 
-
 export const autonomousTradingAction: Action = {
     name: "AUTONOMOUS_TRADING",
     similes: [
@@ -71,7 +88,8 @@ export const autonomousTradingAction: Action = {
         "GROUP_COPY_TRADES",
         "GROUP_COPY_TRADE_WITH_PROFIT",
     ],
-    description: "Select this action when a specific trading rule is being set up, including details like specific wallets to follow, token amounts, time conditions, or other specific parameters for automated trades. Example: 'Buy 10$ worth tokens whenever @[betashop|M4] and @[jessepollak|M739] buy minimum of $50 of any token in 6 hours.",
+    description:
+        "Select this action when a specific trading rule is being set up, including details like specific wallets to follow, token amounts, time conditions, or other specific parameters for automated trades. Example: 'Buy 10$ worth tokens whenever @[betashop|M4] and @[jessepollak|M739] buy minimum of $50 of any token in 6 hours.",
     suppressInitialMessage: true,
     validate: async () => true,
     handler: async (
@@ -81,48 +99,80 @@ export const autonomousTradingAction: Action = {
         _options: { [key: string]: unknown },
         callback: HandlerCallback
     ) => {
-
         const traceId = message.id;
         const moxieUserInfo = state.moxieUserInfo as MoxieUser;
         const moxieUserId = moxieUserInfo.id;
-        
+
         try {
-            elizaLogger.debug(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] Starting AUTONOMOUS_TRADING handler with user message: ${JSON.stringify(message)}`);
+            elizaLogger.debug(
+                traceId,
+                `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] Starting AUTONOMOUS_TRADING handler with user message: ${JSON.stringify(message)}`
+            );
 
             // read moxieUserInfo from state
             const agentWallet = state.agentWallet as MoxieClientWallet;
 
             if (!agentWallet) {
-                elizaLogger.error(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] agentWallet not found`);
+                elizaLogger.error(
+                    traceId,
+                    `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] agentWallet not found`
+                );
                 await callback?.(agentWalletNotFound);
                 return true;
             }
 
             if (!agentWallet.delegated) {
-                elizaLogger.error(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] agentWallet is not delegated`);
+                elizaLogger.error(
+                    traceId,
+                    `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] agentWallet is not delegated`
+                );
                 await callback?.(delegateAccessNotFound);
                 return true;
             }
 
             const walletClient = state.moxieWalletClient as MoxieWalletClient;
             if (!walletClient) {
-                elizaLogger.error(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] walletClient not found`);
+                elizaLogger.error(
+                    traceId,
+                    `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] walletClient not found`
+                );
                 await callback?.(moxieWalletClientNotFound);
                 return true;
             }
 
-            const communicationPreference = await checkUserCommunicationPreferences(traceId, moxieUserId);
-            elizaLogger.debug(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] [checkUserCommunicationPreferences] communicationPreference: ${communicationPreference}`);
+            const communicationPreference =
+                await checkUserCommunicationPreferences(traceId, moxieUserId);
+            elizaLogger.debug(
+                traceId,
+                `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] [checkUserCommunicationPreferences] communicationPreference: ${communicationPreference}`
+            );
 
+            const recentMessageData = state.recentMessagesData.sort(
+                (a, b) => b.createdAt - a.createdAt
+            )[0];
+            const conversationHistoryData = state.recentMessagesData.filter(
+                (message) => message.id !== recentMessageData.id
+            );
             // Compose autonomous trading context
             // Compose swap context
             const swapContext = composeContext({
-                state,
+                state: {
+                    ...state,
+                    recentMessage: recentMessageData.content.text,
+                    conversationHistory:
+                        "# Conversation Messages\n" +
+                        conversationHistoryData
+                            .map(
+                                ({ userId, content, createdAt }) =>
+                                    `(${new Date(createdAt).toLocaleString()})\n${userId}: ${content.text}`
+                            )
+                            .join("\n"),
+                },
                 template: autonomousTradingTemplate,
             });
 
             // Generate swap content
-            const autonomousTradingResponse = await generateObjectDeprecated({
+            const autonomousTradingResponse = (await generateObjectDeprecated({
                 runtime,
                 context: swapContext,
                 modelClass: ModelClass.LARGE,
@@ -132,12 +182,15 @@ export const autonomousTradingAction: Action = {
                     modelProvider: ModelProviderName.ANTHROPIC,
                     apiKey: process.env.ANTHROPIC_API_KEY,
                     modelClass: ModelClass.LARGE,
-                }
-            }) as AutonomousTradingResponse;
+                },
+            })) as AutonomousTradingResponse;
 
-            if (!autonomousTradingResponse.success ) {
-                elizaLogger.warn(traceId,`[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(autonomousTradingResponse.error)}`);
-                 callback?.({
+            if (!autonomousTradingResponse.success) {
+                elizaLogger.warn(
+                    traceId,
+                    `[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(autonomousTradingResponse.error)}`
+                );
+                callback?.({
                     text: autonomousTradingResponse.error.prompt_message,
                     action: "AUTONOMOUS_TRADING",
                 });
@@ -145,50 +198,83 @@ export const autonomousTradingAction: Action = {
             }
 
             // Extract parameters from response
-            const {ruleType, params} = autonomousTradingResponse;
-            
+            const { ruleType, params } = autonomousTradingResponse;
+
             const baseParams: BaseParams = {
                 buyAmount: params.amountInUSD,
                 duration: params.timeDurationInSec,
-                buyAmountValueType: 'USD',
-                sellToken:  {
-                    symbol: 'ETH',
-                    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+                buyAmountValueType: "USD",
+                sellToken: {
+                    symbol: "ETH",
+                    address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
                 },
-                tokenMetrics: (params.tokenAge || params.marketCap) ? {
-                    tokenAge: params.tokenAge ? {
-                        min: params.tokenAge?.min ?? params.tokenAge?.minAgeInSec ?? null,
-                        max: params.tokenAge?.max ?? params.tokenAge?.maxAgeInSec ?? null
-                    } : undefined,
-                    marketCap: params.marketCap ? {
-                        min: params.marketCap?.min ?? params.marketCap?.minMarketCapInUSD ?? null,
-                        max: params.marketCap?.max ?? params.marketCap?.maxMarketCapInUSD ?? null
-                    } : undefined
-                } : undefined
+                tokenMetrics:
+                    params.tokenAge || params.marketCap
+                        ? {
+                              tokenAge: params.tokenAge
+                                  ? {
+                                        min:
+                                            params.tokenAge?.min ??
+                                            params.tokenAge?.minAgeInSec ??
+                                            null,
+                                        max:
+                                            params.tokenAge?.max ??
+                                            params.tokenAge?.maxAgeInSec ??
+                                            null,
+                                    }
+                                  : undefined,
+                              marketCap: params.marketCap
+                                  ? {
+                                        min:
+                                            params.marketCap?.min ??
+                                            params.marketCap
+                                                ?.minMarketCapInUSD ??
+                                            null,
+                                        max:
+                                            params.marketCap?.max ??
+                                            params.marketCap
+                                                ?.maxMarketCapInUSD ??
+                                            null,
+                                    }
+                                  : undefined,
+                          }
+                        : undefined,
             };
 
-            if (params.sellTriggerType === 'COPY_SELL' || params.sellTriggerType === 'BOTH') {
+            if (
+                params.sellTriggerType === "COPY_SELL" ||
+                params.sellTriggerType === "BOTH"
+            ) {
                 baseParams.sellConfig = {
                     buyToken: {
-                        symbol: 'ETH',
-                        address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+                        symbol: "ETH",
+                        address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
                     },
                     // triggerPercentage: params.sellPercentage,
                     triggerPercentage: 50, // Hardcoded for now
-                    condition: params.sellTriggerCondition === 'ANY' ? Condition.ANY : Condition.ALL,
-                    conditionValue: params.sellTriggerCount
+                    condition:
+                        params.sellTriggerCondition === "ANY"
+                            ? Condition.ANY
+                            : Condition.ALL,
+                    conditionValue: params.sellTriggerCount,
                 };
-            };
+            }
 
             let groupTradeParams: GroupTradeParams;
             let userTradeParams: UserTradeParams;
             let limitOrderParams: LimitOrderParams;
-            let ruleTriggers: 'GROUP' | 'USER';
+            let ruleTriggers: "GROUP" | "USER";
 
-            if (ruleType === 'GROUP_COPY_TRADE' || ruleType === 'GROUP_COPY_TRADE_AND_PROFIT') {
-                ruleTriggers = 'GROUP';
+            if (
+                ruleType === "GROUP_COPY_TRADE" ||
+                ruleType === "GROUP_COPY_TRADE_AND_PROFIT"
+            ) {
+                ruleTriggers = "GROUP";
 
-                if (params.condition === 'ANY' && params.sellTriggerCount > params.conditionValue) {
+                if (
+                    params.condition === "ANY" &&
+                    params.sellTriggerCount > params.conditionValue
+                ) {
                     callback?.({
                         text: `The sell trigger count exceeds the numbers of members in the group you are tracking.Please try again with a lower sell trigger count.`,
                         action: "AUTONOMOUS_TRADING",
@@ -201,12 +287,12 @@ export const autonomousTradingAction: Action = {
                     condition: params.condition,
                     conditionValue: params.conditionValue,
                     minPurchaseAmount: {
-                        valueType: 'USD',
-                        amount: params.minPurchaseAmount || 0
-                    }
+                        valueType: "USD",
+                        amount: params.minPurchaseAmount || 0,
+                    },
                 };
             } else {
-                ruleTriggers = 'USER';
+                ruleTriggers = "USER";
                 if (params.sellTriggerCount > params.moxieIds.length) {
                     callback?.({
                         text: `The number of users you are tracking is less than the number of users you are setting the sell trigger count to. Please try again with a lower sell trigger count.`,
@@ -217,19 +303,22 @@ export const autonomousTradingAction: Action = {
                 userTradeParams = {
                     moxieUsers: params.moxieIds,
                     minPurchaseAmount: {
-                        valueType: 'USD',
-                        amount: params.minPurchaseAmount || 0
-                    }
+                        valueType: "USD",
+                        amount: params.minPurchaseAmount || 0,
+                    },
                 };
             }
 
-            if (ruleType === 'GROUP_COPY_TRADE_AND_PROFIT' || ruleType === 'COPY_TRADE_AND_PROFIT') {
+            if (
+                ruleType === "GROUP_COPY_TRADE_AND_PROFIT" ||
+                ruleType === "COPY_TRADE_AND_PROFIT"
+            ) {
                 limitOrderParams = {
                     sellConditions: {
                         sellPercentage: 100,
-                        priceChangePercentage: params.profitPercentage
+                        priceChangePercentage: params.profitPercentage,
                     },
-                    limitOrderValidityInSeconds: 7 * 24 * 60 * 60 // 7 days in seconds
+                    limitOrderValidityInSeconds: 7 * 24 * 60 * 60, // 7 days in seconds
                 };
             }
 
@@ -247,30 +336,34 @@ export const autonomousTradingAction: Action = {
 
                 await callback?.({
                     text: `✅ Automation Rule Created Successfully!\n\n📌 Instruction: ${response.instructions}`,
-                     action: "AUTONOMOUS_TRADING",
-                     cta: communicationPreference === null ? "SETUP_ALERTS" : null
+                    action: "AUTONOMOUS_TRADING",
+                    cta:
+                        communicationPreference === null
+                            ? "SETUP_ALERTS"
+                            : null,
                 });
-
             } catch (error) {
-                elizaLogger.error(traceId,`[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error creating trading rule: ${error.message}`);
+                elizaLogger.error(
+                    traceId,
+                    `[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error creating trading rule: ${error.message}`
+                );
                 callback?.({
                     text: getErrorMessageFromCode(error),
                     action: "AUTONOMOUS_TRADING",
                 });
             }
-
-                
-        } catch(error) {
+        } catch (error) {
             callback?.({
                 text: `Something went wrong while creating autonomous trading rule. Please try again later.`,
                 action: "AUTONOMOUS_TRADING",
             });
-            elizaLogger.error(traceId,`[[autonomous trading]] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(error)}`);
-
+            elizaLogger.error(
+                traceId,
+                `[[autonomous trading]] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(error)}`
+            );
         }
 
         return true;
-
     },
     examples: [
         [
@@ -294,7 +387,8 @@ export const autonomousTradingAction: Action = {
 export const getAutonomousTradingRuleDetailAction: Action = {
     name: "COPY_TRADE_RULE_DETAILS",
     similes: ["AUTONOMOUS_TRADING_RULE_DETAILS"],
-    description: "Select this action when the request is seeking information about possible automation types, available parameters, or general questions about what copy trading functionality exists. Example: 'What automations are possible?' or 'What kinds of trading rules can I create?",
+    description:
+        "Select this action when the request is seeking information about possible automation types, available parameters, or general questions about what copy trading functionality exists. Example: 'What automations are possible?' or 'What kinds of trading rules can I create?",
     suppressInitialMessage: true,
     validate: async () => true,
     handler: async (
@@ -304,14 +398,15 @@ export const getAutonomousTradingRuleDetailAction: Action = {
         _options: { [key: string]: unknown },
         callback: HandlerCallback
     ) => {
-
         const user = state.moxieUserInfo as MoxieUser;
 
-        const response = getAutonomousTradingRuleDetails(formatUserMention(user.id, user.userName));
+        const response = getAutonomousTradingRuleDetails(
+            formatUserMention(user.id, user.userName)
+        );
         callback({
-            text: response, 
+            text: response,
             action: "COPY_TRADE_RULE_DETAILS",
-            cta: ["COPY_TRADE", "GROUP_COPY_TRADE", "AUTO_BUY_AUTO_SELL"]
+            cta: ["COPY_TRADE", "GROUP_COPY_TRADE", "AUTO_BUY_AUTO_SELL"],
         });
     },
     examples: [
@@ -324,4 +419,4 @@ export const getAutonomousTradingRuleDetailAction: Action = {
             },
         ],
     ] as ActionExample[][],
-};  
+};

--- a/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
+++ b/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
@@ -146,28 +146,10 @@ export const autonomousTradingAction: Action = {
                 traceId,
                 `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] [checkUserCommunicationPreferences] communicationPreference: ${communicationPreference}`
             );
-
-            const recentMessageData = state.recentMessagesData.sort(
-                (a, b) => b.createdAt - a.createdAt
-            )[0];
-            const conversationHistoryData = state.recentMessagesData.filter(
-                (message) => message.id !== recentMessageData.id
-            );
             // Compose autonomous trading context
             // Compose swap context
             const swapContext = composeContext({
-                state: {
-                    ...state,
-                    recentMessage: recentMessageData.content.text,
-                    conversationHistory:
-                        "# Conversation Messages\n" +
-                        conversationHistoryData
-                            .map(
-                                ({ userId, content, createdAt }) =>
-                                    `(${new Date(createdAt).toLocaleString()})\n${userId}: ${content.text}`
-                            )
-                            .join("\n"),
-                },
+                state,
                 template: autonomousTradingTemplate,
             });
 

--- a/packages/plugin-moxie-autonomous-trading/src/templates.ts
+++ b/packages/plugin-moxie-autonomous-trading/src/templates.ts
@@ -1,15 +1,20 @@
 export const autonomousTradingTemplate = `
-You are an AI assistant specialized in extracting parameters for cryptocurrency copy trading rules. Your task is to analyze user inputs and determine the rule type and relevant parameters for setting up automated trading strategies.
+You are an AI assistant specialized in extracting parameters for cryptocurrency copy trading rules. Your task is to analyze user's latest message based on the context of the conversation history and determine the rule type and relevant parameters for setting up automated trading strategies.
+
+Here is the latest user input you need to analyze:
+<latest_user_input>
+{{recentMessage}}
+</latest_user_input>
 
 Here is the conversation history containing the user input you need to analyze:
 
 <conversation_history>
-{{recentMessages}}
+{{conversationHistory}}
 </conversation_history>
 
 Please follow these steps to process the user input and generate the appropriate output:
 
-1. Analyze the conversation history to identify the most recent user input related to a copy trading rule. Focus only on the latest message from the user.
+1. Focus only on the latest message from the user. Analyze the conversation history if necessary to identify the most recent user input related to a copy trading rule.
 
 2. Determine the rule type based on the input. There are four possible rule types:
    a. COPY_TRADE
@@ -58,6 +63,8 @@ Please follow these steps to process the user input and generate the appropriate
 
 6. If the current input appears to be a follow-up to a previous question, only then extract any missing information from the earlier conversation. Otherwise, ignore the previous conversation and focus only on the current input.
 
+7. Check if the user has changed their intent and has requested a different rule type. If so, DO NOT use the conversation history to answer the user's question.
+
 Before providing the final JSON output, show your reasoning process inside <rule_extraction> tags. In your analysis:
 
 1. Quote the most recent user input related to a copy trading rule.
@@ -91,7 +98,7 @@ If all required parameters are present, use this format for the JSON output:
   "is_followup": false,
   "params": {
     // Include relevant parameters based on the rule type
-    // Include optional token-level filters if present 
+    // Include optional token-level filters if present
   },
   "error": null
 }

--- a/packages/plugin-moxie-autonomous-trading/src/templates.ts
+++ b/packages/plugin-moxie-autonomous-trading/src/templates.ts
@@ -1,15 +1,10 @@
 export const autonomousTradingTemplate = `
 You are an AI assistant specialized in extracting parameters for cryptocurrency copy trading rules. Your task is to analyze user's latest message based on the context of the conversation history and determine the rule type and relevant parameters for setting up automated trading strategies.
 
-Here is the latest user input you need to analyze:
-<latest_user_input>
-{{recentMessage}}
-</latest_user_input>
-
 Here is the conversation history containing the user input you need to analyze:
 
 <conversation_history>
-{{conversationHistory}}
+{{recentMessages}}
 </conversation_history>
 
 Please follow these steps to process the user input and generate the appropriate output:
@@ -24,7 +19,7 @@ Please follow these steps to process the user input and generate the appropriate
 
    Use these guidelines to determine the rule type:
    - If the input mentions a group (contains "#["), it's a GROUP rule.
-   - If it mentions selling based on profit, it's a PROFIT rule.
+   - If it mentions selling based on profit, it's a PROFIT rule. Otherwise, it profit is not mentioned as the selling condition, e.g. sell when other users sell, it's not a PROFIT rule.
    - Combine these factors to determine the exact rule type.
    - Important: The presence of multiple individual users (e.g., "@[user1|id1] and @[user2|id2]") does NOT indicate a GROUP rule. Only use GROUP rules when "#[" is present.
 


### PR DESCRIPTION
# Background

There's a bit of hallucination in selecting between `GROUP_COPY_TRADE` and `GROUP_COPY_TRADE_AND_PROFIT` in a room with lots of `AUTONOMOUS_TRADING` requests.

Looks like it generally stems when the sell condition specified is based on when the user copied is selling instead of profit %.

For example, this is a valid request but in long conversation it hallucinates:

![image](https://github.com/user-attachments/assets/6ba62008-9cad-4dd5-ab16-d51349223570)

# PR Category

- [ ] Register New Skills (first time adding new skills to moxie.xyz)
- [ ] Bug Fixes (non-breaking change which fixes an issue)
    - [ ] Low
    - [ ] Medium
    - [ ] High
- [x] Improvements (misc. changes to existing features)
- [ ] New Features (non-breaking change which adds functionality)
- [ ] Updates (new versions of included code)

# Description

Improve the prompt for the agent to process so that `PROFIT` is only chosen when sell condition by profit is specified. Otherwise, if there's no such condition specified, then it's not a `PROFIT` type.