### PR TITLE
Error message improvement for auto trading

### DIFF
--- a/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
+++ b/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
@@ -217,7 +217,7 @@ export const autonomousTradingAction: Action = {
                 return true;
             }
 
-            if (params.groupId && validate(params.groupId)) {
+            if (params.groupId && !validate(params.groupId)) {
                 callback?.({
                     text: `Please provide a valid group in the following format: #groupname. Remember to select the group from the dropdown and press 'Enter' to confirm.`,
                     action: "AUTONOMOUS_TRADING",

--- a/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
+++ b/packages/plugin-moxie-autonomous-trading/src/actions/index.ts
@@ -11,10 +11,29 @@ import {
     composeContext,
     generateObjectDeprecated,
 } from "@moxie-protocol/core";
-import { MoxieClientWallet, MoxieUser, MoxieWalletClient, formatUserMention } from "@moxie-protocol/moxie-agent-lib";
-import { BaseParams, createTradingRule, getAutonomousTradingRuleDetails, getErrorMessageFromCode, GroupTradeParams, LimitOrderParams, RuleType, StopLossParams,
-    UserTradeParams, agentWalletNotFound, delegateAccessNotFound, moxieWalletClientNotFound, checkUserCommunicationPreferences, Condition } from "../utils/utility";
+import {
+    MoxieClientWallet,
+    MoxieUser,
+    MoxieWalletClient,
+    formatUserMention,
+} from "@moxie-protocol/moxie-agent-lib";
+import {
+    BaseParams,
+    createTradingRule,
+    getAutonomousTradingRuleDetails,
+    getErrorMessageFromCode,
+    GroupTradeParams,
+    LimitOrderParams,
+    RuleType,
+    StopLossParams,
+    UserTradeParams,
+    agentWalletNotFound,
+    moxieWalletClientNotFound,
+    checkUserCommunicationPreferences,
+    Condition,
+} from "../utils/utility";
 import { autonomousTradingTemplate } from "../templates";
+import { validate } from "uuid";
 
 export interface TokenAge {
     min?: number;
@@ -36,11 +55,11 @@ export interface AutonomousTradingRuleParams {
     timeDurationInSec: number;
     amountInUSD: number;
     profitPercentage?: number;
-    condition?: 'ANY' | 'ALL';
+    condition?: "ANY" | "ALL";
     conditionValue?: number;
     minPurchaseAmount?: number;
-    sellTriggerType?: 'LIMIT_ORDER' | 'COPY_SELL' | 'BOTH';
-    sellTriggerCondition?: 'ANY' | 'ALL';
+    sellTriggerType?: "LIMIT_ORDER" | "COPY_SELL" | "BOTH";
+    sellTriggerCondition?: "ANY" | "ALL";
     sellTriggerCount?: number;
     sellPercentage?: number;
     tokenAge?: TokenAge;
@@ -62,7 +81,6 @@ export interface AutonomousTradingResponse {
     error: AutonomousTradingError | null;
 }
 
-
 export const autonomousTradingAction: Action = {
     name: "AUTONOMOUS_TRADING",
     similes: [
@@ -73,7 +91,8 @@ export const autonomousTradingAction: Action = {
         "GROUP_COPY_TRADES",
         "GROUP_COPY_TRADE_WITH_PROFIT",
     ],
-    description: "Select this action when a specific trading rule is being set up, including details like specific wallets to follow, token amounts, time conditions, or other specific parameters for automated trades. Example: 'Buy 10$ worth tokens whenever @[betashop|M4] and @[jessepollak|M739] buy minimum of $50 of any token in 6 hours.",
+    description:
+        "Select this action when a specific trading rule is being set up, including details like specific wallets to follow, token amounts, time conditions, or other specific parameters for automated trades. Example: 'Buy 10$ worth tokens whenever @[betashop|M4] and @[jessepollak|M739] buy minimum of $50 of any token in 6 hours.",
     suppressInitialMessage: true,
     validate: async () => true,
     handler: async (
@@ -83,32 +102,44 @@ export const autonomousTradingAction: Action = {
         _options: { [key: string]: unknown },
         callback: HandlerCallback
     ) => {
-
         const traceId = message.id;
         const moxieUserInfo = state.moxieUserInfo as MoxieUser;
         const moxieUserId = moxieUserInfo.id;
-        
+
         try {
-            elizaLogger.debug(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] Starting AUTONOMOUS_TRADING handler with user message: ${JSON.stringify(message)}`);
+            elizaLogger.debug(
+                traceId,
+                `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] Starting AUTONOMOUS_TRADING handler with user message: ${JSON.stringify(message)}`
+            );
 
             // read moxieUserInfo from state
             const agentWallet = state.agentWallet as MoxieClientWallet;
 
             if (!agentWallet) {
-                elizaLogger.error(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] agentWallet not found`);
+                elizaLogger.error(
+                    traceId,
+                    `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] agentWallet not found`
+                );
                 await callback?.(agentWalletNotFound);
                 return true;
             }
 
             const walletClient = state.moxieWalletClient as MoxieWalletClient;
             if (!walletClient) {
-                elizaLogger.error(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] walletClient not found`);
+                elizaLogger.error(
+                    traceId,
+                    `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] walletClient not found`
+                );
                 await callback?.(moxieWalletClientNotFound);
                 return true;
             }
 
-            const communicationPreference = await checkUserCommunicationPreferences(traceId, moxieUserId);
-            elizaLogger.debug(traceId,`[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] [checkUserCommunicationPreferences] communicationPreference: ${communicationPreference}`);
+            const communicationPreference =
+                await checkUserCommunicationPreferences(traceId, moxieUserId);
+            elizaLogger.debug(
+                traceId,
+                `[AUTONOMOUS_TRADING] [${moxieUserId}] [AUTONOMOUS_TRADING] [checkUserCommunicationPreferences] communicationPreference: ${communicationPreference}`
+            );
 
             // Compose autonomous trading context
             // Compose swap context
@@ -118,7 +149,7 @@ export const autonomousTradingAction: Action = {
             });
 
             // Generate swap content
-            const autonomousTradingResponse = await generateObjectDeprecated({
+            const autonomousTradingResponse = (await generateObjectDeprecated({
                 runtime,
                 context: swapContext,
                 modelClass: ModelClass.LARGE,
@@ -128,12 +159,15 @@ export const autonomousTradingAction: Action = {
                     modelProvider: ModelProviderName.ANTHROPIC,
                     apiKey: process.env.ANTHROPIC_API_KEY,
                     modelClass: ModelClass.LARGE,
-                }
-            }) as AutonomousTradingResponse;
+                },
+            })) as AutonomousTradingResponse;
 
-            if (!autonomousTradingResponse.success ) {
-                elizaLogger.warn(traceId,`[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(autonomousTradingResponse.error)}`);
-                 callback?.({
+            if (!autonomousTradingResponse.success) {
+                elizaLogger.warn(
+                    traceId,
+                    `[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(autonomousTradingResponse.error)}`
+                );
+                callback?.({
                     text: autonomousTradingResponse.error.prompt_message,
                     action: "AUTONOMOUS_TRADING",
                 });
@@ -141,9 +175,13 @@ export const autonomousTradingAction: Action = {
             }
 
             // Extract parameters from response
-            const {ruleType, params} = autonomousTradingResponse;
+            const { ruleType, params } = autonomousTradingResponse;
 
-            if (params.moxieIds && params.moxieIds.length > 1 && !params.timeDurationInSec) {
+            if (
+                params.moxieIds &&
+                params.moxieIds.length > 1 &&
+                !params.timeDurationInSec
+            ) {
                 callback?.({
                     text: `Please specify the duration between which copied traders make trades to be counted for the rule`,
                     action: "AUTONOMOUS_TRADING",
@@ -151,7 +189,11 @@ export const autonomousTradingAction: Action = {
                 return true;
             }
 
-            if (params.conditionValue && params.conditionValue > 1 && !params.timeDurationInSec) {
+            if (
+                params.conditionValue &&
+                params.conditionValue > 1 &&
+                !params.timeDurationInSec
+            ) {
                 callback?.({
                     text: `Please specify the duration between which copied traders make trades to be counted for the rule`,
                     action: "AUTONOMOUS_TRADING",
@@ -166,51 +208,101 @@ export const autonomousTradingAction: Action = {
                 });
                 return true;
             }
-            
+
+            if (!params.amountInUSD) {
+                callback?.({
+                    text: `Please specify the amount of tokens in USD you want the agent to buy.`,
+                    action: "AUTONOMOUS_TRADING",
+                });
+                return true;
+            }
+
+            if (params.groupId && validate(params.groupId)) {
+                callback?.({
+                    text: `Please provide a valid group in the following format: #groupname. Remember to select the group from the dropdown and press 'Enter' to confirm.`,
+                    action: "AUTONOMOUS_TRADING",
+                });
+                return true;
+            }
+
             const baseParams: BaseParams = {
                 buyAmount: params.amountInUSD,
                 duration: params.timeDurationInSec,
-                buyAmountValueType: 'USD',
-                sellToken:  {
-                    symbol: 'ETH',
-                    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+                buyAmountValueType: "USD",
+                sellToken: {
+                    symbol: "ETH",
+                    address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
                 },
-                tokenMetrics: (params.tokenAge || params.marketCap) ? {
-                    tokenAge: params.tokenAge ? {
-                        min: params.tokenAge?.min ?? params.tokenAge?.minAgeInSec ?? null,
-                        max: params.tokenAge?.max ?? params.tokenAge?.maxAgeInSec ?? null
-                    } : undefined,
-                    marketCap: params.marketCap ? {
-                        min: params.marketCap?.min ?? params.marketCap?.minMarketCapInUSD ?? null,
-                        max: params.marketCap?.max ?? params.marketCap?.maxMarketCapInUSD ?? null
-                    } : undefined
-                } : undefined
+                tokenMetrics:
+                    params.tokenAge || params.marketCap
+                        ? {
+                              tokenAge: params.tokenAge
+                                  ? {
+                                        min:
+                                            params.tokenAge?.min ??
+                                            params.tokenAge?.minAgeInSec ??
+                                            null,
+                                        max:
+                                            params.tokenAge?.max ??
+                                            params.tokenAge?.maxAgeInSec ??
+                                            null,
+                                    }
+                                  : undefined,
+                              marketCap: params.marketCap
+                                  ? {
+                                        min:
+                                            params.marketCap?.min ??
+                                            params.marketCap
+                                                ?.minMarketCapInUSD ??
+                                            null,
+                                        max:
+                                            params.marketCap?.max ??
+                                            params.marketCap
+                                                ?.maxMarketCapInUSD ??
+                                            null,
+                                    }
+                                  : undefined,
+                          }
+                        : undefined,
             };
 
-            if (params.sellTriggerType === 'COPY_SELL' || (params.sellTriggerType === 'BOTH' && (params?.sellTriggerCondition || params?.sellTriggerCount))) {
+            if (
+                params.sellTriggerType === "COPY_SELL" ||
+                (params.sellTriggerType === "BOTH" &&
+                    (params?.sellTriggerCondition || params?.sellTriggerCount))
+            ) {
                 baseParams.sellConfig = {
                     buyToken: {
-                        symbol: 'ETH',
-                        address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+                        symbol: "ETH",
+                        address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
                     },
                     // triggerPercentage: params.sellPercentage,
                     triggerPercentage: 50, // Hardcoded for now
-                    condition: params.sellTriggerCondition === 'ANY' ? Condition.ANY : Condition.ALL,
-                    conditionValue: params.sellTriggerCount
+                    condition:
+                        params.sellTriggerCondition === "ANY"
+                            ? Condition.ANY
+                            : Condition.ALL,
+                    conditionValue: params.sellTriggerCount,
                 };
-            };
+            }
 
             let groupTradeParams: GroupTradeParams;
             let userTradeParams: UserTradeParams;
             let limitOrderParams: LimitOrderParams;
             let stopLossParams: StopLossParams;
 
-            let ruleTriggers: 'GROUP' | 'USER';
+            let ruleTriggers: "GROUP" | "USER";
 
-            if (ruleType === 'GROUP_COPY_TRADE' || ruleType === 'GROUP_COPY_TRADE_AND_PROFIT') {
-                ruleTriggers = 'GROUP';
+            if (
+                ruleType === "GROUP_COPY_TRADE" ||
+                ruleType === "GROUP_COPY_TRADE_AND_PROFIT"
+            ) {
+                ruleTriggers = "GROUP";
 
-                if (params.condition === 'ANY' && params.sellTriggerCount > params.conditionValue) {
+                if (
+                    params.condition === "ANY" &&
+                    params.sellTriggerCount > params.conditionValue
+                ) {
                     callback?.({
                         text: `The sell trigger count exceeds the numbers of members in the group you are tracking.Please try again with a lower sell trigger count.`,
                         action: "AUTONOMOUS_TRADING",
@@ -223,12 +315,12 @@ export const autonomousTradingAction: Action = {
                     condition: params.condition,
                     conditionValue: params.conditionValue,
                     minPurchaseAmount: {
-                        valueType: 'USD',
-                        amount: params.minPurchaseAmount || 0
-                    }
+                        valueType: "USD",
+                        amount: params.minPurchaseAmount || 0,
+                    },
                 };
             } else {
-                ruleTriggers = 'USER';
+                ruleTriggers = "USER";
                 if (params.sellTriggerCount > params.moxieIds.length) {
                     callback?.({
                         text: `The number of users you are tracking is less than the number of users you are setting the sell trigger count to. Please try again with a lower sell trigger count.`,
@@ -239,19 +331,22 @@ export const autonomousTradingAction: Action = {
                 userTradeParams = {
                     moxieUsers: params.moxieIds,
                     minPurchaseAmount: {
-                        valueType: 'USD',
-                        amount: params.minPurchaseAmount || 0
-                    }
+                        valueType: "USD",
+                        amount: params.minPurchaseAmount || 0,
+                    },
                 };
             }
 
-            if (ruleType === 'GROUP_COPY_TRADE_AND_PROFIT' || ruleType === 'COPY_TRADE_AND_PROFIT') {
+            if (
+                ruleType === "GROUP_COPY_TRADE_AND_PROFIT" ||
+                ruleType === "COPY_TRADE_AND_PROFIT"
+            ) {
                 limitOrderParams = {
                     sellConditions: {
                         sellPercentage: 100,
-                        priceChangePercentage: params.profitPercentage
+                        priceChangePercentage: params.profitPercentage,
                     },
-                    limitOrderValidityInSeconds: 7 * 24 * 60 * 60 // 7 days in seconds
+                    limitOrderValidityInSeconds: 7 * 24 * 60 * 60, // 7 days in seconds
                 };
             }
 
@@ -259,9 +354,10 @@ export const autonomousTradingAction: Action = {
                 stopLossParams = {
                     sellConditions: {
                         sellPercentage: 100,
-                        priceChangePercentage: params.stopLossPercentage
+                        priceChangePercentage: params.stopLossPercentage,
                     },
-                    stopLossValidityInSeconds: params.stopLossDurationInSec || 7 * 24 * 60 * 60
+                    stopLossValidityInSeconds:
+                        params.stopLossDurationInSec || 7 * 24 * 60 * 60,
                 };
             }
 
@@ -280,30 +376,34 @@ export const autonomousTradingAction: Action = {
 
                 await callback?.({
                     text: `✅ Automation Rule Created Successfully!\n\n📌 Instruction: ${response.instructions}`,
-                     action: "AUTONOMOUS_TRADING",
-                     cta: communicationPreference === null ? "SETUP_ALERTS" : null
+                    action: "AUTONOMOUS_TRADING",
+                    cta:
+                        communicationPreference === null
+                            ? "SETUP_ALERTS"
+                            : null,
                 });
-
             } catch (error) {
-                elizaLogger.error(traceId,`[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error creating trading rule: ${error.message}`);
+                elizaLogger.error(
+                    traceId,
+                    `[autonomous trading] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error creating trading rule: ${error.message}`
+                );
                 callback?.({
                     text: getErrorMessageFromCode(error),
                     action: "AUTONOMOUS_TRADING",
                 });
             }
-
-                
-        } catch(error) {
+        } catch (error) {
             callback?.({
                 text: `Something went wrong while creating autonomous trading rule. Please try again later.`,
                 action: "AUTONOMOUS_TRADING",
             });
-            elizaLogger.error(traceId,`[[autonomous trading]] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(error)}`);
-
+            elizaLogger.error(
+                traceId,
+                `[[autonomous trading]] [${moxieUserId}] [AUTONOMOUS_TRADING] [ADD_RULE] error occured while performing add rule operation: ${JSON.stringify(error)}`
+            );
         }
 
         return true;
-
     },
     examples: [
         [
@@ -327,7 +427,8 @@ export const autonomousTradingAction: Action = {
 export const getAutonomousTradingRuleDetailAction: Action = {
     name: "COPY_TRADE_RULE_DETAILS",
     similes: ["AUTONOMOUS_TRADING_RULE_DETAILS"],
-    description: "Select this action when the request is seeking information about possible automation types, available parameters, or general questions about what copy trading functionality exists. Example: 'What automations are possible?' or 'What kinds of trading rules can I create?",
+    description:
+        "Select this action when the request is seeking information about possible automation types, available parameters, or general questions about what copy trading functionality exists. Example: 'What automations are possible?' or 'What kinds of trading rules can I create?",
     suppressInitialMessage: true,
     validate: async () => true,
     handler: async (
@@ -337,14 +438,15 @@ export const getAutonomousTradingRuleDetailAction: Action = {
         _options: { [key: string]: unknown },
         callback: HandlerCallback
     ) => {
-
         const user = state.moxieUserInfo as MoxieUser;
 
-        const response = getAutonomousTradingRuleDetails(formatUserMention(user.id, user.userName));
+        const response = getAutonomousTradingRuleDetails(
+            formatUserMention(user.id, user.userName)
+        );
         callback({
-            text: response, 
+            text: response,
             action: "COPY_TRADE_RULE_DETAILS",
-            cta: ["COPY_TRADE", "GROUP_COPY_TRADE", "AUTO_BUY_AUTO_SELL"]
+            cta: ["COPY_TRADE", "GROUP_COPY_TRADE", "AUTO_BUY_AUTO_SELL"],
         });
     },
     examples: [
@@ -357,4 +459,4 @@ export const getAutonomousTradingRuleDetailAction: Action = {
             },
         ],
     ] as ActionExample[][],
-};  
+};

--- a/packages/plugin-moxie-autonomous-trading/src/utils/utility.ts
+++ b/packages/plugin-moxie-autonomous-trading/src/utils/utility.ts
@@ -1,7 +1,11 @@
-import { elizaLogger } from '@moxie-protocol/core';
-import { gql } from 'graphql-request';
+import { elizaLogger } from "@moxie-protocol/core";
+import { gql } from "graphql-request";
 
-export type RuleType = 'COPY_TRADE' | 'COPY_TRADE_AND_PROFIT' | 'GROUP_COPY_TRADE' | 'GROUP_COPY_TRADE_AND_PROFIT';
+export type RuleType =
+    | "COPY_TRADE"
+    | "COPY_TRADE_AND_PROFIT"
+    | "GROUP_COPY_TRADE"
+    | "GROUP_COPY_TRADE_AND_PROFIT";
 
 export interface SellToken {
     symbol: string;
@@ -14,13 +18,13 @@ export interface BuyToken {
 }
 
 export interface Amount {
-    valueType: 'USD';
+    valueType: "USD";
     amount: number;
 }
 
 export enum Condition {
     ALL = "ALL",
-    ANY = "ANY"
+    ANY = "ANY",
 }
 
 export interface SellConfig {
@@ -48,7 +52,7 @@ export interface TokenMetrics {
 export interface BaseParams {
     buyAmount: number;
     duration: number;
-    buyAmountValueType: 'USD';
+    buyAmountValueType: "USD";
     sellToken: SellToken;
     sellConfig?: SellConfig;
     tokenMetrics?: TokenMetrics;
@@ -72,9 +76,9 @@ export interface StopLossParams {
 
 export interface GroupTradeParams {
     groupId: string;
-    condition: 'ANY' | 'ALL';
+    condition: "ANY" | "ALL";
     conditionValue: number;
-    minPurchaseAmount: Amount
+    minPurchaseAmount: Amount;
 }
 
 export interface UserTradeParams {
@@ -92,7 +96,7 @@ export interface CreateRuleInput {
         groupTradeParams?: GroupTradeParams;
         userTradeParams?: UserTradeParams;
     };
-    ruleTrigger: 'GROUP' | 'USER';
+    ruleTrigger: "GROUP" | "USER";
 }
 
 export type Group = {
@@ -103,7 +107,7 @@ export type Group = {
     updatedAt: string;
     members: GroupMember[];
     status: Status;
-}
+};
 
 export interface GroupMember {
     moxieUserId: string;
@@ -114,7 +118,7 @@ export interface GroupMember {
 
 export enum Status {
     ACTIVE = "ACTIVE",
-    INACTIVE = "INACTIVE"
+    INACTIVE = "INACTIVE",
 }
 
 export interface GetGroupsOutput {
@@ -173,56 +177,83 @@ export const GET_GROUP_DETAILS = gql`
 // errorMessages.ts
 
 const errorMessages: Record<string, string> = {
-    AERR001: "Some required fields are missing. Please make sure you've provided all the necessary details.",
-    AERR002: "We couldn’t understand who should trigger the rule — is it an copy trade or a group copy trade?",
-    AERR003: "We need basic trading details to create this rule. Please add those.",
+    AERR001:
+        "Some required fields are missing. Please make sure you've provided all the necessary details.",
+    AERR002:
+        "We couldn’t understand who should trigger the rule — is it an copy trade or a group copy trade?",
+    AERR003:
+        "We need basic trading details to create this rule. Please add those.",
     AERR004: "The amount to buy must be more than zero.",
     AERR005: "Please choose whether the buy amount is in dollars.",
-    AERR006: "Duration must be a positive number (like minutes or hours or seconds).",
-    AERR007: "The token name you're selling to buy incoming tokens is missing. Please provide it.",
-    AERR008: "The address of the token you're selling to buy incoming tokens is missing. Please add it.",
-    AERR009: "The token address which you're selling to buy incoming tokens doesn't look right. Please check if it's a valid wallet address.",
-    AERR010: "We need user-specific trade details to continue. (e.g. @username)",
+    AERR006:
+        "Duration must be a positive number (like minutes or hours or seconds).",
+    AERR007:
+        "The token name you're selling to buy incoming tokens is missing. Please provide it.",
+    AERR008:
+        "The address of the token you're selling to buy incoming tokens is missing. Please add it.",
+    AERR009:
+        "The token address which you're selling to buy incoming tokens doesn't look right. Please check if it's a valid wallet address.",
+    AERR010:
+        "We need user-specific trade details to continue. (e.g. @username)",
     AERR011: "The minimum purchase amount must be a positive number.",
     AERR012: "Please choose if the minimum amount is in dollars.",
-    AERR013: "To use a group-based rule, group details are needed. (e.g. #groupname)",
+    AERR013:
+        "To use a group-based rule, group details are needed. (e.g. #groupname)",
     AERR014: "At least one user must be selected to copy trades from.",
-    AERR015: "You're using a user-based rule — group settings should not be included.",
+    AERR015:
+        "You're using a user-based rule — group settings should not be included.",
     AERR016: "You cannot copy trades from yourself.",
-    AERR017: "Missing group-based settings. Please provide group ID and conditions.",
-    AERR018: "Group rules must include both the group and the condition (like ALL or ANY).",
+    AERR017:
+        "Missing group-based settings. Please provide group ID and conditions.",
+    AERR018:
+        "Group rules must include both the group and the condition (like ALL or ANY).",
     AERR019: "Please tell us how many members should meet the condition.",
     AERR020: "The condition value must be zero or higher.",
-    AERR021: "You’re using a group rule — user-based settings should not be included.",
+    AERR021:
+        "You’re using a group rule — user-based settings should not be included.",
     AERR022: "To use profit-taking, please define when to sell.",
-    AERR023: "At least one sell condition (e.g., price goes up by 10%) is required.",
+    AERR023:
+        "At least one sell condition (e.g., price goes up by 10%) is required.",
     AERR024: "Both price change % and sell % must be numbers.",
     AERR025: "The profit percentage must be more or equal to 1.",
     AERR026: "The sell percentage must be more or equal to 1.",
-    AERR027: "Set how long the limit order should stay active — it must be a positive number.",
+    AERR027:
+        "Set how long the limit order should stay active — it must be a positive number.",
     AERR028: "Limit order settings are only allowed for profit-taking rules.",
     AERR029: "Please provide sell conditions to enable profit-taking.",
-    AERR030: "We couldn’t generate the rule’s instructions. Please check the details.",
+    AERR030:
+        "We couldn’t generate the rule’s instructions. Please check the details.",
     AERR031: "You’re not authorized. Please sign in again.",
     AERR032: "We couldn’t find your user account. Please try reconnecting.",
     AERR033: "We had trouble fetching your rules. Please try again shortly.",
     AERR034: "Something went wrong while creating the rule. Please try again.",
-    AERR035: "We couldn’t delete one or more rules. Please make sure you created them.",
+    AERR035:
+        "We couldn’t delete one or more rules. Please make sure you created them.",
     AERR036: "We had trouble loading your automation logs. Please try again.",
     AERR037: "We couldn’t find the group. Please check the group ID.",
-    AERR038: "You’ve set a condition that’s higher than the number of people in the group.",
-    AERR039: "The token name you're selling to from the token you bought is missing. Please provide it.",
-    AERR040: "The address of the token you're selling to from the token you bought is missing. Please add it.",
-    AERR041: "The address of the token you're selling to from the token you bought is not a valid Base address. Please add a valid address.",
+    AERR038:
+        "You’ve set a condition that’s higher than the number of people in the group.",
+    AERR039:
+        "The token name you're selling to from the token you bought is missing. Please provide it.",
+    AERR040:
+        "The address of the token you're selling to from the token you bought is missing. Please add it.",
+    AERR041:
+        "The address of the token you're selling to from the token you bought is not a valid Base address. Please add a valid address.",
     AERR042: "The trigger percentage must be a positive number",
-    AERR043: "The condition for selling is a mandatory field. Please provide it.",
+    AERR043:
+        "The condition for selling is a mandatory field. Please provide it.",
     AERR044: "The sell condition value must be a non-negative number",
-    AERR045: "Number of users for sell condition is provided bigger than the actual users in the rule. Please provide lower number.",
-    AERR046: "Number of users for sell condition is provided bigger than actual users in the group. Please provide lower number.",
+    AERR045:
+        "Number of users for sell condition is provided bigger than the actual users in the rule. Please provide lower number.",
+    AERR046:
+        "Number of users for sell condition is provided bigger than actual users in the group. Please provide lower number.",
     AERR050: "At least one user must be selected to copy trades from.",
-    AERR051: "Please check if valid Senpi user is tagged e.g. @[betashop.eth|M4].",
-    AERR052: "Minimum token age and maximum token age must be non-negative numbers",
-    AERR053: "Minimum market cap and maximum market cap must be non-negative numbers",
+    AERR051:
+        "Please check if valid Senpi user is tagged e.g. @[betashop.eth|M4].",
+    AERR052:
+        "Minimum token age and maximum token age must be non-negative numbers",
+    AERR053:
+        "Minimum market cap and maximum market cap must be non-negative numbers",
     AERR054: "Minimum token age must be less than maximum token age",
     AERR055: "Minimum market cap must be less than maximum market cap",
     AERR056: "Stop loss sell conditions not provided",
@@ -231,11 +262,16 @@ const errorMessages: Record<string, string> = {
     AERR059: "Stop loss sell percentage must be greater than 0%",
     AERR060: "Agent wallet not found",
     AERR061: "Delegate access not found for agent wallet",
-    AERR062: "Something went wrong while activating the rule. Please try again.",
-    AERR201: "Please try again with a valid group. Make sure to use '#' to select from your available groups. You can also ask me to create a new group by typing: create the group [groupname]",
-    AERR202: "Please add members to the group before setting up auto-trading. For example: add @betashop.eth to #copytrade",
-    AERR203: "Hi, I'd be happy to help you setup that auto-trade but there are less members in the group than the copy traded users count. You can ask me to add more members by typing: add [user] to [groupname]",
-    AERR204: "Hi, I'd be happy to help you setup that auto-trade but there are less members in the group than the sell condition value. You can ask me to add more members by typing: add [user] to [groupname]",
+    AERR062:
+        "Something went wrong while activating the rule. Please try again.",
+    AERR201:
+        "Please try again with a valid group. Make sure to use '#' to select from your available groups. You can also ask me to create a new group by typing: create the group [groupname]",
+    AERR202:
+        "Please add members to the group before setting up auto-trading. For example: add @betashop.eth to #copytrade",
+    AERR203:
+        "Hi, I'd be happy to help you setup that auto-trade but there are less members in the group than the copy traded users count. You can ask me to add more members by typing: add [user] to [groupname]",
+    AERR204:
+        "Hi, I'd be happy to help you setup that auto-trade but there are less members in the group than the sell condition value. You can ask me to add more members by typing: add [user] to [groupname]",
 };
 
 export function getErrorMessageFromCode(error: Error | string): string {
@@ -247,7 +283,7 @@ export function getErrorMessageFromCode(error: Error | string): string {
     } else {
         return `Hi, I'd be happy to help you setup that auto-trade but we just need some more information first. \n&nbsp;\n
 
-1. Make sure to specify who triggers the copy trade. Examples: if @[user] buys a token or if 2 people in #groupname. 
+1. Make sure to specify who triggers the copy trade. Examples: if @[user] buys a token or if 2 people in #groupname.
 2. Make sure to specify a trigger amount: e.g. if 2 people in #copytrade buy >$1000 of a token.
 3. Make sure to specify a time period, e.g. "if 2 people in #copytrade buy >$1000 of a token within 30 minutes of each other..."
 4. Make sure to specify an amount to buy for you: "if 2 people in #copytrade buy >$1000 of a token within 30 minutes of each other, buy me $400 of it..."
@@ -259,39 +295,43 @@ If 2 people in #copytrade buy >$1000 of a token within 30 minutes of each other,
     }
 }
 
-
 export async function createTradingRule(
     authorizationHeader: string,
     requestId: string,
     ruleType: RuleType,
     baseParams: BaseParams,
-    ruleTrigger: 'GROUP' | 'USER',
+    ruleTrigger: "GROUP" | "USER",
     groupTradeParams?: GroupTradeParams,
     userTradeParams?: UserTradeParams,
     limitOrderParams?: LimitOrderParams,
     stopLossParams?: StopLossParams
 ): Promise<CreateRuleResponse> {
-
     // Ensure either groupTradeParams or userTradeParams is provided, but not both
-    if (ruleTrigger === 'GROUP' && !groupTradeParams) {
-        throw new Error('Please provide groupTradeParams (e.g. #groupname, condition: ANY|ALL, conditionValue: number, minPurchaseAmount: number) when using a GROUP rule.');
+    if (ruleTrigger === "GROUP" && !groupTradeParams) {
+        throw new Error(
+            "Please provide groupTradeParams (e.g. #groupname, condition: ANY|ALL, conditionValue: number, minPurchaseAmount: number) when using a GROUP rule."
+        );
     }
 
-    if (ruleTrigger === 'USER' && !userTradeParams) {
-        throw new Error('Please provide userTradeParams (e.g. @username, minPurchaseAmount: number) when using a USER rule.');
+    if (ruleTrigger === "USER" && !userTradeParams) {
+        throw new Error(
+            "Please provide userTradeParams (e.g. @username, minPurchaseAmount: number) when using a USER rule."
+        );
     }
 
     if (groupTradeParams && userTradeParams) {
-        throw new Error('Provide only one: groupTradeParams or userTradeParams, not both.');
+        throw new Error(
+            "Provide only one: groupTradeParams or userTradeParams, not both."
+        );
     }
 
     const createRuleInput: CreateRuleInput = {
         requestId,
         ruleType,
         ruleParameters: {
-            baseParams
+            baseParams,
         },
-        ruleTrigger
+        ruleTrigger,
     };
 
     if (limitOrderParams) {
@@ -304,26 +344,44 @@ export async function createTradingRule(
 
     if (groupTradeParams) {
         createRuleInput.ruleParameters.groupTradeParams = groupTradeParams;
-        const groupDetails = await getGroupDetails(authorizationHeader, groupTradeParams.groupId);
+        const groupDetails = await getGroupDetails(
+            authorizationHeader,
+            groupTradeParams.groupId
+        );
 
         if (groupDetails.groups.length === 0) {
-            throw new Error('AERR201: Group not found. Please check the group ID.');
+            throw new Error(
+                "AERR201: Group not found. Please check the group ID."
+            );
         }
 
         const groupMembersLength = groupDetails.groups[0].members.length;
 
         if (groupMembersLength === 0) {
-            throw new Error('AERR202: The group has no members. Please add members to the group.');
+            throw new Error(
+                "AERR202: The group has no members. Please add members to the group."
+            );
         }
 
-        if (groupTradeParams.condition === 'ANY' && groupMembersLength < groupTradeParams.conditionValue) {
-            throw new Error('AERR203: The number of users in the group is less than the buy condition value. Please provide a lower condition value.');
+        if (
+            groupTradeParams.condition === "ANY" &&
+            groupMembersLength < groupTradeParams.conditionValue
+        ) {
+            throw new Error(
+                "AERR203: The number of users in the group is less than the buy condition value. Please provide a lower condition value."
+            );
         }
 
-        if (createRuleInput?.ruleParameters?.baseParams?.sellConfig && groupMembersLength < createRuleInput.ruleParameters.baseParams.sellConfig.conditionValue) {
-            throw new Error('AERR204: The number of users in the group is less than the sell condition value. Please provide a lower condition value.');
+        if (
+            createRuleInput?.ruleParameters?.baseParams?.sellConfig &&
+            groupMembersLength <
+                createRuleInput.ruleParameters.baseParams.sellConfig
+                    .conditionValue
+        ) {
+            throw new Error(
+                "AERR204: The number of users in the group is less than the sell condition value. Please provide a lower condition value."
+            );
         }
-
     }
 
     if (userTradeParams) {
@@ -332,32 +390,34 @@ export async function createTradingRule(
 
     try {
         const response = await fetch(process.env.RULE_API_MOXIE_API_URL, {
-            method: 'POST',
+            method: "POST",
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': authorizationHeader
+                "Content-Type": "application/json",
+                Authorization: authorizationHeader,
             },
             body: JSON.stringify({
                 query: mutation,
-                variables: { createRuleInput }
-            })
+                variables: { createRuleInput },
+            }),
         });
 
         const result = await response.json();
 
         if (result.errors) {
-            throw new Error(`Failed to create rule: ${result.errors[0].message}`);
+            throw new Error(
+                `Failed to create rule: ${result.errors[0].message}`
+            );
         }
 
         return result.data.CreateRule as CreateRuleResponse;
-
     } catch (error) {
         elizaLogger.error(`CreateRule failed: ${error}`);
         throw new Error(`Error creating trading rule: ${error.message}`);
     }
 }
 
-export const getAutonomousTradingRuleDetails = (currentUser: string) => `Hi there! \n \nI can help you easily set up auto-trading — so you never miss that alpha. Here are some examples of auto-trades I can currently do: \n \n1. Auto-buy: If any 2 people in #copytrade buy >$500 of a token within 10 minutes of each other, buy me $100 of it. Set stop loss at 10%. \n2. Auto-buy + Limit sell: If any 2 people in #copytrade buy >$1000 of a token within 10 minutes of each other, buy me $100 of it, and then sell all of it for 30% profit. Set stop loss at 10%. \n3. Auto-buy + Auto-sell: If any 2 people in #copytrade buy >$2000 of a token within 10 minutes of each other, buy me $100 of it, and then sell all of it when 1 of them sell 50%. Set stop loss at 10%. \n4. Auto-buy + combo sell: If any 2 people in #copytrade buy >$4000 of a token within 10 minutes of each other, buy me $100 of it, and then sell all of it when any 1 of them sell 50% OR when it increases by 50%. Set stop loss at 10%. \n5. Auto-buy-mcap + combo-sell: If any 3 people in #copytrade buy >$500 of a token within 15 minutes of each other, and it is <$1M marketcap, buy me $100 of it, and then sell all of it when any 2 of them sell 50% OR when it increases by 50%. Set stop loss at 10%. \n6. Auto-buy-age + combo-sell: If any 2 people in #copytrade buy >$500 of a token within 10 minutes of each other, and it was created <24 hours ago, buy me $100 of it, and then sell when they sell. Set stop loss at 10%. \n \nGo to Groups to set up your #copytrade group and create additional groups. \n \nThen just use #[groupname] to create your auto-trade rules! \n \nCopy and edit the prompts above or start with one of the templates below — just tweak it to fit your strategy!`;
+export const getAutonomousTradingRuleDetails = (currentUser: string) =>
+    `Hi there! \n \nI can help you easily set up auto-trading — so you never miss that alpha. Here are some examples of auto-trades I can currently do: \n \n1. Auto-buy: If any 2 people in #copytrade buy >$500 of a token within 10 minutes of each other, buy me $100 of it. Set stop loss at 10%. \n2. Auto-buy + Limit sell: If any 2 people in #copytrade buy >$1000 of a token within 10 minutes of each other, buy me $100 of it, and then sell all of it for 30% profit. Set stop loss at 10%. \n3. Auto-buy + Auto-sell: If any 2 people in #copytrade buy >$2000 of a token within 10 minutes of each other, buy me $100 of it, and then sell all of it when 1 of them sell 50%. Set stop loss at 10%. \n4. Auto-buy + combo sell: If any 2 people in #copytrade buy >$4000 of a token within 10 minutes of each other, buy me $100 of it, and then sell all of it when any 1 of them sell 50% OR when it increases by 50%. Set stop loss at 10%. \n5. Auto-buy-mcap + combo-sell: If any 3 people in #copytrade buy >$500 of a token within 15 minutes of each other, and it is <$1M marketcap, buy me $100 of it, and then sell all of it when any 2 of them sell 50% OR when it increases by 50%. Set stop loss at 10%. \n6. Auto-buy-age + combo-sell: If any 2 people in #copytrade buy >$500 of a token within 10 minutes of each other, and it was created <24 hours ago, buy me $100 of it, and then sell when they sell. Set stop loss at 10%. \n \nGo to Groups to set up your #copytrade group and create additional groups. \n \nThen just use #[groupname] to create your auto-trade rules! \n \nCopy and edit the prompts above or start with one of the templates below — just tweak it to fit your strategy!`;
 
 export const agentWalletNotFound = {
     text: `\nPlease make sure to set up your agent wallet first and try again.`,
@@ -371,12 +431,15 @@ export const moxieWalletClientNotFound = {
     text: `\nUnable to access moxie wallet details. Please ensure your moxie wallet is properly setup and try again.`,
 };
 
-export async function checkUserCommunicationPreferences(traceId: string, moxieUserId: string): Promise<string | null> {
+export async function checkUserCommunicationPreferences(
+    traceId: string,
+    moxieUserId: string
+): Promise<string | null> {
     try {
         const response = await fetch(process.env.MOXIE_API_URL_INTERNAL, {
-            method: 'POST',
+            method: "POST",
             headers: {
-                'Content-Type': 'application/json',
+                "Content-Type": "application/json",
             },
             body: JSON.stringify({
                 query: `
@@ -385,21 +448,30 @@ export async function checkUserCommunicationPreferences(traceId: string, moxieUs
                             communicationPreference
                         }
                     }
-                `
-            })
+                `,
+            }),
         });
 
         if (!response.ok) {
-            elizaLogger.error(traceId, `[AUTONOMOUS_TRADING] [${moxieUserId}] Failed to fetch user preferences: ${response.statusText}`);
+            elizaLogger.error(
+                traceId,
+                `[AUTONOMOUS_TRADING] [${moxieUserId}] Failed to fetch user preferences: ${response.statusText}`
+            );
             return null;
         }
 
         const data = await response.json();
-        elizaLogger.debug(traceId, `[AUTONOMOUS_TRADING] [${moxieUserId}] User communication preferences:`, data?.data?.GetUser?.communicationPreference);
+        elizaLogger.debug(
+            traceId,
+            `[AUTONOMOUS_TRADING] [${moxieUserId}] User communication preferences:`,
+            data?.data?.GetUser?.communicationPreference
+        );
         return data?.data?.GetUser?.communicationPreference;
-
     } catch (error) {
-        elizaLogger.error(traceId, `[AUTONOMOUS_TRADING] [${moxieUserId}] Error checking user preferences: ${error.message}`);
+        elizaLogger.error(
+            traceId,
+            `[AUTONOMOUS_TRADING] [${moxieUserId}] Error checking user preferences: ${error.message}`
+        );
         return null;
     }
 }
@@ -409,44 +481,53 @@ export async function getGroupDetails(
     groupId?: string,
     groupName?: string,
     skip: number = 0,
-    take: number = 10,
+    take: number = 10
 ): Promise<GetGroupsOutput> {
-    elizaLogger.info('getGroupDetails called', { groupId, groupName, skip, take });
+    elizaLogger.info("getGroupDetails called", {
+        groupId,
+        groupName,
+        skip,
+        take,
+    });
 
     try {
         const input: GetGroupsInput = {
             ...(groupId && { groupId }),
             ...(groupName && { groupName }),
             ...(skip !== undefined && { skip }),
-            ...(take !== undefined && { take })
+            ...(take !== undefined && { take }),
         };
 
-        elizaLogger.debug('getGroupDetails input constructed', { input });
+        elizaLogger.debug("getGroupDetails input constructed", { input });
 
         const data = await fetch(process.env.RULE_API_MOXIE_API_URL, {
-            method: 'POST',
+            method: "POST",
             headers: {
-                'Content-Type': 'application/json',
-                'Authorization': authorizationHeader
+                "Content-Type": "application/json",
+                Authorization: authorizationHeader,
             },
             body: JSON.stringify({
                 query: GET_GROUP_DETAILS,
-                variables: { input }
-            })
+                variables: { input },
+            }),
         });
 
-        elizaLogger.debug('getGroups fetch completed', { status: data.status });
+        elizaLogger.debug("getGroups fetch completed", { status: data.status });
 
         const result = await data.json();
         if (result.errors) {
-            elizaLogger.error('getGroups failed', { errors: result.errors });
-            throw new Error(`Failed to get groups: ${result.errors[0].message}`);
+            elizaLogger.error("getGroups failed", { errors: result.errors });
+            throw new Error(
+                `Failed to get groups: ${result.errors[0].message}`
+            );
         }
 
-        elizaLogger.info('getGroups successful', { data: result.data.GetGroups });
+        elizaLogger.info("getGroups successful", {
+            data: result.data.GetGroups,
+        });
         return result.data.GetGroups;
     } catch (error) {
-        elizaLogger.error('Error in getGroups', { error: error.message });
-        throw new Error(`Error fetching groups: ${error.message}`);
+        elizaLogger.error("Error in getGroups", { error: error.message });
+        throw new Error(`AERR201: Error fetching groups: ${error.message}`);
     }
 }


### PR DESCRIPTION
Improving error messages when user is missing to provide a param instead of just the generic response template to provide more clarity for user on what to do next

While most cases have custom messages, here are some cases that still just return generic response that get fixed in the PR:
- Does not specify the amount bought by copy traded user (`amountInUsd`)
- Valid group id (`groupId`), some times user just provide #groupName without pressing 'Enter' and the group name is assigned as `groupId` instead
