### PR TITLE
Burn token instead of dusting when insufficient liquidity

### DIFF
--- a/packages/plugin-wallet-duster/src/actions/dustWalletAction.ts
+++ b/packages/plugin-wallet-duster/src/actions/dustWalletAction.ts
@@ -216,7 +216,8 @@ export const dustWalletAction: Action = {
                     agentWallet.address,
                     provider,
                     callback,
-                    wallet
+                    wallet,
+                    threshold
                 );
                 if (dustedToken !== null) {
                     dustedTokenCount++;

--- a/packages/plugin-wallet-duster/src/constants/constants.ts
+++ b/packages/plugin-wallet-duster/src/constants/constants.ts
@@ -75,6 +75,29 @@ export const ERC20_ABI = [
         stateMutability: "view",
         type: "function",
     },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: "_to",
+                type: "address",
+            },
+            {
+                name: "_value",
+                type: "uint256",
+            },
+        ],
+        name: "transfer",
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+            },
+        ],
+        payable: false,
+        stateMutability: "nonpayable",
+        type: "function",
+    },
 ];
 
 export const mockGetQuoteResponse: GetQuoteResponse = {

--- a/packages/plugin-wallet-duster/src/utils/swap.ts
+++ b/packages/plugin-wallet-duster/src/utils/swap.ts
@@ -162,7 +162,7 @@ export async function swap(
                 });
             }
 
-            return null;
+            return buyAmountInWEI;
         }
         // for other currencies we need to check allowance and approve spending
         // check allowance and approve spending

--- a/packages/plugin-wallet-duster/src/utils/swap.ts
+++ b/packages/plugin-wallet-duster/src/utils/swap.ts
@@ -349,16 +349,17 @@ export async function swap(
         if (!txnReceipt) {
             elizaLogger.error(
                 traceId,
-                `[tokenSwap] [${moxieUserId}] [swap] txnReceipt is null`
+                `[tokenSwap] [${moxieUserId}] [swap] [TRANSACTION_RECEIPT_NULL] txnReceipt is null`
             );
             await callback?.({
-                text: `\nTransaction is failed. Please try again`,
+                text: `\nTransaction failed. Please try again.`,
                 content: {
-                    error: "TRANSACTION_RECEIPT_NULL",
                     details: `Transaction receipt is not present for ${tx.hash}.`,
                 },
             });
-            throw new Error("Transaction receipt is null");
+            throw new Error(
+                "[TRANSACTION_RECEIPT_NULL] Transaction receipt is null"
+            );
         }
     } catch (error) {
         elizaLogger.error(


### PR DESCRIPTION
- Execute burn when no sufficient liquidity to dust the token
- Minor: change message when transaction failed and remove `error` so agent response is displayed